### PR TITLE
Allow tenant name to disable jwt auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We try to solve this problem by adding a Gateway which can be considered the ent
 | `-gateway.distributor.address` | Upstream HTTP URL for Cortex Distributor | (empty string) |
 | `-gateway.query-frontend.address` | Upstream HTTP URL for Cortex Query Frontend | (empty string) |
 | `-gateway.auth.jwt-secret` | HMAC secret to sign JSON Web Tokens | (empty string) |
+| `-gateway.auth.tenant-name` | The tenant name to use when you want to disable jwt auth, if specified the jwt secret value is ignored | (empty string) |
 
 ### Expected JWT payload
 

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -34,7 +34,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&tenantName, "gateway.auth.tenantName", "", "Tenant name to use when jwt auth disabled")
+	flag.StringVar(&tenantName, "gateway.auth.tenant-name", "", "Tenant name to use when jwt auth disabled")
 	flag.StringVar(&jwtSecret, "gateway.auth.jwt-secret", "", "Secret to sign JSON Web Tokens")
 	flag.StringVar(&extraHeadersArg, "gateway.auth.jwt-extra-headers", "", "A comma separated list of additional headers to scan for JSON Web Tokens presence")
 }

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -19,6 +19,7 @@ import (
 var (
 	jwtSecret       string
 	extraHeadersArg string
+	tenantName      string
 
 	authFailures = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "cortex_gateway",
@@ -33,6 +34,7 @@ var (
 )
 
 func init() {
+	flag.StringVar(&tenantName, "gateway.auth.tenantName", "", "Tenant name to use when jwt auth disabled")
 	flag.StringVar(&jwtSecret, "gateway.auth.jwt-secret", "", "Secret to sign JSON Web Tokens")
 	flag.StringVar(&extraHeadersArg, "gateway.auth.jwt-extra-headers", "", "A comma separated list of additional headers to scan for JSON Web Tokens presence")
 }
@@ -48,45 +50,52 @@ var AuthenticateTenant = middleware.Func(func(next http.Handler) http.Handler {
 	authorizationHeaderExtractor := buildHeaderExtractor(extraHeaders)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger := klog.With(log.WithContext(r.Context(), log.Logger), "ip_address", r.RemoteAddr)
-		level.Debug(logger).Log("msg", "authenticating request", "route", r.RequestURI)
 
-		if !requestContainsToken(r, headers) {
-			level.Info(logger).Log("msg", "no bearer token provided")
-			http.Error(w, "No bearer token provided", http.StatusUnauthorized)
-			authFailures.WithLabelValues("no_token").Inc()
-			return
+		if tenantName != "" {
+			r.Header.Set("X-Scope-OrgID", tenantName)
+			next.ServeHTTP(w, r)
+		} else {
+			logger := klog.With(log.WithContext(r.Context(), log.Logger), "ip_address", r.RemoteAddr)
+			level.Debug(logger).Log("msg", "authenticating request", "route", r.RequestURI)
+
+			if !requestContainsToken(r, headers) {
+				level.Info(logger).Log("msg", "no bearer token provided")
+				http.Error(w, "No bearer token provided", http.StatusUnauthorized)
+				authFailures.WithLabelValues("no_token").Inc()
+				return
+			}
+
+			// Try to parse and validate JWT
+			te := &tenant{}
+			_, err := jwtReq.ParseFromRequest(
+				r,
+				authorizationHeaderExtractor,
+				func(token *jwt.Token) (interface{}, error) {
+					// Only HMAC algorithms accepted - algorithm validation is super important!
+					if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+						level.Info(logger).Log("msg", "unexpected signing method", "used_method", token.Header["alg"])
+						return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+					}
+
+					return []byte(jwtSecret), nil
+				},
+				jwtReq.WithClaims(te))
+
+			// If Tenant's Valid method returns false an error will be set as well, hence there is no need
+			// to additionally check the parsed token for "Valid"
+			if err != nil {
+				level.Info(logger).Log("msg", "invalid bearer token", "err", err.Error())
+				http.Error(w, "Invalid bearer token", http.StatusUnauthorized)
+				authFailures.WithLabelValues("token_not_valid").Inc()
+				return
+			}
+
+			// Token is valid
+			authSuccess.WithLabelValues(te.TenantID).Inc()
+			r.Header.Set("X-Scope-OrgID", te.TenantID)
+			next.ServeHTTP(w, r)
 		}
 
-		// Try to parse and validate JWT
-		te := &tenant{}
-		_, err := jwtReq.ParseFromRequest(
-			r,
-			authorizationHeaderExtractor,
-			func(token *jwt.Token) (interface{}, error) {
-				// Only HMAC algorithms accepted - algorithm validation is super important!
-				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-					level.Info(logger).Log("msg", "unexpected signing method", "used_method", token.Header["alg"])
-					return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
-				}
-
-				return []byte(jwtSecret), nil
-			},
-			jwtReq.WithClaims(te))
-
-		// If Tenant's Valid method returns false an error will be set as well, hence there is no need
-		// to additionally check the parsed token for "Valid"
-		if err != nil {
-			level.Info(logger).Log("msg", "invalid bearer token", "err", err.Error())
-			http.Error(w, "Invalid bearer token", http.StatusUnauthorized)
-			authFailures.WithLabelValues("token_not_valid").Inc()
-			return
-		}
-
-		// Token is valid
-		authSuccess.WithLabelValues(te.TenantID).Inc()
-		r.Header.Set("X-Scope-OrgID", te.TenantID)
-		next.ServeHTTP(w, r)
 	})
 })
 


### PR DESCRIPTION
At this point, the gateway only supports jwt auth. This PR allows the user to specify a tenant name which allows the gateway to run without jwt auth. The tenant name specified is directly added to the X-Scope-OrgID header to determine the cortex tenant.