### PR TITLE
Add JWKS support and the other Digital Signatures alg

### DIFF
--- a/gateway/jwks.go
+++ b/gateway/jwks.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"flag"
+	"time"
+
+	"github.com/MicahParks/keyfunc"
+	"github.com/cortexproject/cortex/pkg/util/log"
+	klog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+var (
+	jwksURL             string
+	jwksRefreshEnabled  bool
+	jwksRefreshInterval int
+	jwksRefreshTimeout  int
+)
+
+func init() {
+	flag.StringVar(&jwksURL, "gateway.auth.jwks-url", "", "The URL to load the JWKS (JSON Web Key Set) from")
+	flag.BoolVar(&jwksRefreshEnabled, "gateway.auth.jwks-refresh-enabled", false, "Enable the JWKS background refresh. (Default: false)")
+	flag.IntVar(&jwksRefreshInterval, "gateway.auth.jwks-refresh-interval", 60, "The JWKS background refresh interval in minutes. (Defaults: 60 minutes)")
+	flag.IntVar(&jwksRefreshTimeout, "gateway.auth.jwks-refresh-timeout", 30, "The JWKS background refresh timeout in seconds. (Defaults: 30 seconds)")
+}
+
+func newJWKS() *keyfunc.JWKS {
+	if jwksURL == "" {
+		return keyfunc.NewGiven(map[string]keyfunc.GivenKey{})
+	}
+	logger := klog.With(log.Logger)
+	options := keyfunc.Options{}
+	if jwksRefreshEnabled {
+		level.Debug(logger).Log("msg", "JWKS background refresh enabled", "URL", jwksURL, "interval", jwksRefreshInterval, "timeout", jwksRefreshTimeout)
+		options.RefreshInterval = time.Minute * time.Duration(jwksRefreshInterval)
+		options.RefreshTimeout = time.Second * time.Duration(jwksRefreshTimeout)
+		options.RefreshErrorHandler = func(err error) {
+			level.Error(logger).Log("msg", "Refreshing JWKS failed", "URL", jwksURL, "err", err.Error())
+		}
+	}
+	jwks, err := keyfunc.Get(jwksURL, options)
+	if err != nil {
+		level.Error(logger).Log("msg", "Create JWKS from url failed", "URL", jwksURL, "err", err.Error())
+		return keyfunc.NewGiven(map[string]keyfunc.GivenKey{})
+	}
+	return jwks
+}

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -50,6 +50,7 @@ var AuthenticateTenant = middleware.Func(func(next http.Handler) http.Handler {
 	}
 	headers := append(extraHeaders, "Authorization")
 	authorizationHeaderExtractor := buildHeaderExtractor(extraHeaders)
+	jwks := newJWKS()
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -76,6 +77,8 @@ var AuthenticateTenant = middleware.Func(func(next http.Handler) http.Handler {
 			func(token *jwt.Token) (interface{}, error) {
 				keyAlg := token.Method.Alg()
 				switch keyAlg {
+				case "RS256", "RS384", "RS512", "EdDSA", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512":
+					return jwks.Keyfunc(token)
 				case "HS256", "HS384", "HS512":
 					return []byte(jwtSecret), nil
 				}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/deliveryhero/cortex-gateway
 go 1.18
 
 require (
+	github.com/MicahParks/keyfunc v1.0.3
 	github.com/cortexproject/cortex v1.11.1
 	github.com/go-kit/kit v0.12.0
 	github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.16.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/squirrel v0.0.0-20161115235646-20f192218cf5/go.mod h1:xnKTFzjGUiZtiOagBsfnvomW+nJg2usB1ZpordQWqNM=
+github.com/MicahParks/keyfunc v1.0.3 h1:rKakzF/Gd2QjFPCqSG9SshrWs0oRZffc/c4pVjCXDr0=
+github.com/MicahParks/keyfunc v1.0.3/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -790,6 +792,7 @@ github.com/gogo/status v1.0.3/go.mod h1:SavQ51ycCLnc7dGyJxp8YAmudx8xqiVrRf+6IXRs
 github.com/gogo/status v1.1.0 h1:+eIkrewn5q6b30y+g/BJINVVdi2xH7je5MPJ3ZPK3JA=
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-migrate/migrate/v4 v4.7.0/go.mod h1:Qvut3N4xKWjoH3sokBccML6WyHSnggXm/DvMMnTsQIc=


### PR DESCRIPTION
Add support for Token signed with RSA, ECDSA, EdDSA,... algorithms. Use JWKS to download and find the Public certificate.
This is to allow Prometheus remote write using OAuth2 (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2)