### PR TITLE
Handle auth disable case in config validation

### DIFF
--- a/gateway/config.go
+++ b/gateway/config.go
@@ -75,8 +75,8 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("alertmanager address must start with a valid scheme (http/https). Given is '%v'", cfg.AlertManagerAddress)
 	}
 
-	if cfg.JwtSecret == "" && cfg.JwksURL == "" {
-		return fmt.Errorf("you must set -gateway.auth.jwt-secret and/or -gateway.auth.jwks-url")
+	if cfg.JwtSecret == "" && cfg.JwksURL == "" && cfg.TenantName == "" {
+		return fmt.Errorf("you must set -gateway.auth.jwt-secret and/or -gateway.auth.jwks-url or -gateway.auth.tenantName")
 	}
 
 	if cfg.JwksRefreshInterval <= 0 {


### PR DESCRIPTION
Fix the config validation in the case when a tenant name is provided and auth is disabled